### PR TITLE
Fix artificial butter bug

### DIFF
--- a/recipes.lua
+++ b/recipes.lua
@@ -335,7 +335,7 @@ minetest.register_craft({
 	recipe = {	{"group:dye,color_yellow", "cucina_vegana:soy_milk",  "cucina_vegana:soy_milk"}
 			},
 			replacements = {
-                            {"cucina_vegana:soy_milk", "vessels:drinking_glass"}
+                            {"cucina_vegana:soy_milk", "vessels:drinking_glass 2"}
 						}
 })
 


### PR DESCRIPTION
In the file "recipes.lua" (line 338) the cucina_vegana:soy_milk is replaced only ONE time with the drinking glass and not two times. So we would EAT some glass if we would eat the artificial butter made...  
This is a fix for that to return TWO instead of ONE drinking glasses and so, only the soy is crafted to artificial butter. 